### PR TITLE
added _RequestError to handle HTTP errors

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -48,6 +48,7 @@ interface Params {
     _RenderResponseItems: any;
     _Select:              any;
     _Url:                 any;
+    _RequestError:        any;
 
     // Internal item
     $AjaxTimer:           number;
@@ -222,7 +223,8 @@ class AutoComplete {
                             function(response: string) {
                                 this._Render(this._Post(response));
                                 this._Open();
-                            }.bind(this)
+                            }.bind(this),
+                            this._RequestError
                         );
                     }
                 },
@@ -494,6 +496,11 @@ class AutoComplete {
             }
             this.Input.setAttribute("data-autocomplete-old-value", this.Input.value);
         },
+        /**
+         * Handle HTTP error on the request
+         */
+        _RequestError: function(): void {
+        },
 
         $AjaxTimer: null,
         $Cache: {},
@@ -601,7 +608,7 @@ class AutoComplete {
         }
     }
 
-    makeRequest(params: Params, callback: any): XMLHttpRequest {
+    makeRequest(params: Params, callback: any, callbackErr: any): XMLHttpRequest {
         var propertyHttpHeaders: string[] = Object.getOwnPropertyNames(params.HttpHeaders),
             request: XMLHttpRequest = new XMLHttpRequest(),
             method: string = params._HttpMethod(),
@@ -628,6 +635,9 @@ class AutoComplete {
                 params.$Cache[queryParams] = request.response;
                 callback(request.response);
             }
+            else if (request.status >= 400) {
+                callbackErr();
+            }
         };
 
         return request;
@@ -650,11 +660,11 @@ class AutoComplete {
         }
     }
 
-    cache(params: Params, callback: any): void {
+    cache(params: Params, callback: any, callbackErr: any): void {
         var response: string|undefined = params._Cache(params._Pre());
 
         if (response === undefined) {
-            var request: XMLHttpRequest = AutoComplete.prototype.makeRequest(params, callback);
+            var request: XMLHttpRequest = AutoComplete.prototype.makeRequest(params, callback, callbackErr);
 
             AutoComplete.prototype.ajax(params, request);
         } else {


### PR DESCRIPTION
in case the http call to the server fails for whatever reason, there's no way to know it failed and what happened, and _Post won't get executed. I add here _RequestError to be able to handle this case.

Imagine you executed something pre-call, like showing a loader image, if the call fails you want to know it so you can take your actions back. That's the goal of _RequestError.

I left it empty because there's hardly any default behaviour for this. Parameters can be added (like http's original error response) but I leave it to the maintainer.